### PR TITLE
fix: indexページのUI改善

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,6 @@
     <div class="container">
       <header>
         <h1>RSS Translator Bridge</h1>
-        <p>RSSフィードを翻訳してご利用いただけます</p>
       </header>
 
       <div class="form-section">
@@ -62,7 +61,7 @@
         class="performance-section"
         id="performanceSection"
         style="display: none">
-        <h3>パフォーマンス情報</h3>
+        <h3>リクエスト情報</h3>
         <div class="performance-info">
           <div class="performance-item">
             <span class="label">レスポンス時間:</span>
@@ -75,6 +74,18 @@
           <div class="performance-item">
             <span class="label">処理開始時刻:</span>
             <span id="startTime">-</span>
+          </div>
+          <div class="performance-item">
+            <span class="label">APIエンドポイントURL:</span>
+            <div class="url-controls">
+              <input type="text" id="requestUrl" readonly />
+              <button type="button" id="copyUrlBtn" title="URLをコピー">
+                📋
+              </button>
+              <button type="button" id="openUrlBtn" title="別タブで開く">
+                🔗
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,7 @@
             <span class="label">処理開始時刻:</span>
             <span id="startTime">-</span>
           </div>
-          <div class="performance-item">
+          <div class="performance-item url-item">
             <span class="label">APIエンドポイントURL:</span>
             <div class="url-controls">
               <input type="text" id="requestUrl" readonly />

--- a/public/index.html
+++ b/public/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RSS Translator Bridge</title>
+    <title>book000/rss-translator-bridge</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <div class="container">
       <header>
-        <h1>RSS Translator Bridge</h1>
+        <h1>book000/rss-translator-bridge</h1>
       </header>
 
       <div class="form-section">

--- a/public/style.css
+++ b/public/style.css
@@ -135,6 +135,46 @@ button:disabled {
   color: #2c3e50;
 }
 
+.url-controls {
+  display: flex;
+  gap: 8px;
+  margin-top: 5px;
+}
+
+.url-controls input[type='text'] {
+  flex: 1;
+  padding: 8px 12px;
+  border: 2px solid #e0e6ed;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: monospace;
+  background-color: #f8f9fa;
+}
+
+.url-controls button {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  width: auto;
+  min-width: 40px;
+}
+
+.url-controls button:hover {
+  transform: none;
+  opacity: 0.8;
+}
+
+.url-controls button[title*='コピー'] {
+  background: #27ae60;
+}
+
+.url-controls button[title*='開く'] {
+  background: #8e44ad;
+}
+
 .results-section {
   background: white;
   padding: 20px;

--- a/public/style.css
+++ b/public/style.css
@@ -135,10 +135,15 @@ button:disabled {
   color: #2c3e50;
 }
 
+.performance-item.url-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .url-controls {
   display: flex;
   gap: 8px;
-  margin-top: 5px;
 }
 
 .url-controls input[type='text'] {

--- a/public/style.css
+++ b/public/style.css
@@ -119,7 +119,7 @@ button:disabled {
 
 .performance-info {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 15px;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -139,6 +139,7 @@ button:disabled {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  grid-column: 1 / -1; /* グリッド全体の幅を使用 */
 }
 
 .url-controls {


### PR DESCRIPTION
## 概要
Issue #16で要求されたindexページのUI改善を実装しました。

## 変更内容
- 「RSSフィードを翻訳してご利用いただけます」テキストを削除
- 「パフォーマンス情報」セクションを「リクエスト情報」に名称変更
- APIエンドポイントURLを表示する機能を追加
  - 翻訳リクエスト後にreadonly inputでAPIエンドポイントURLを表示
  - コピーボタン（📋）でURLをクリップボードにコピー
  - 別タブで開くボタン（🔗）でURLを新しいタブで開く

## テスト内容
- 既存テストの実行確認
- lint/test/typecheckが全て通ることを確認
- ESLintルールに従いwindowをglobalThisに変更

## チェックリスト
- [x] ローカルでlint/testが通ることを確認
- [x] 既存機能に影響がないことを確認
- [x] Issue要件を満たしていることを確認

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>