### PR TITLE
feat: 記事タイトルを翻訳しないオプションを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ HOST=0.0.0.0
 # Default Language Settings (Optional)
 DEFAULT_SOURCE_LANG=auto
 DEFAULT_TARGET_LANG=ja
+
+# Translation Exclusion Settings (Optional)
+# DEFAULT_EXCLUDE_FEED_TITLE=true  # Exclude RSS feed title from translation (default: true)
+# DEFAULT_EXCLUDE_ITEM_TITLE=false # Exclude RSS item titles from translation (default: false)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ pnpm fix:eslint
 - `HOST`: サーバーホスト（デフォルト: 0.0.0.0）
 - `DEFAULT_SOURCE_LANG`: デフォルトソース言語（デフォルト: auto）
 - `DEFAULT_TARGET_LANG`: デフォルトターゲット言語（デフォルト: ja）
+- `DEFAULT_EXCLUDE_FEED_TITLE`: RSS フィードタイトルを翻訳しないかどうか（デフォルト: true）
+- `DEFAULT_EXCLUDE_ITEM_TITLE`: RSS 記事タイトルを翻訳しないかどうか（デフォルト: false）
 
 ## API仕様
 
@@ -94,6 +96,8 @@ RSSフィードを翻訳して返すメインエンドポイント
 - `url` (必須): 翻訳対象のRSSフィードURL
 - `sourceLang` (オプション): ソース言語コード
 - `targetLang` (オプション): ターゲット言語コード
+- `excludeFeedTitle` (オプション): RSS フィードタイトルを翻訳しないかどうか（true/false）
+- `excludeItemTitle` (オプション): RSS 記事タイトルを翻訳しないかどうか（true/false）
 
 **レスポンス:** 翻訳済みRSS XML または エラーJSON
 

--- a/public/index.html
+++ b/public/index.html
@@ -60,7 +60,17 @@
                 id="excludeFeedTitle"
                 name="excludeFeedTitle"
                 checked />
-              フィードタイトルを翻訳しない（記事タイトルのみ翻訳）
+              フィードタイトルを翻訳しない
+            </label>
+          </div>
+
+          <div class="form-group">
+            <label>
+              <input
+                type="checkbox"
+                id="excludeItemTitle"
+                name="excludeItemTitle" />
+              記事タイトルを翻訳しない
             </label>
           </div>
 

--- a/public/script.js
+++ b/public/script.js
@@ -27,6 +27,7 @@ class RSSTranslator {
     const sourceLang = formData.get('sourceLang')
     const targetLang = formData.get('targetLang')
     const excludeFeedTitle = formData.get('excludeFeedTitle') ? 'true' : 'false'
+    const excludeItemTitle = formData.get('excludeItemTitle') ? 'true' : 'false'
 
     if (!url) {
       this.showError('RSS URLを入力してください')
@@ -47,7 +48,8 @@ class RSSTranslator {
         url,
         sourceLang,
         targetLang,
-        excludeFeedTitle
+        excludeFeedTitle,
+        excludeItemTitle
       )
 
       // 並行で実行
@@ -110,12 +112,19 @@ class RSSTranslator {
     }
   }
 
-  async translateRSS(url, sourceLang, targetLang, excludeFeedTitle) {
+  async translateRSS(
+    url,
+    sourceLang,
+    targetLang,
+    excludeFeedTitle,
+    excludeItemTitle
+  ) {
     const parameters = new URLSearchParams({
       url,
       sourceLang: sourceLang || 'auto',
       targetLang: targetLang || 'ja',
       excludeFeedTitle,
+      excludeItemTitle,
     })
 
     const requestUrl = `${globalThis.location.origin}/api?${parameters}`

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -160,4 +160,50 @@ describe('loadConfig', () => {
       expect(config.defaultExcludeFeedTitle).toBe(true)
     })
   })
+
+  describe('defaultExcludeItemTitle handling', () => {
+    beforeEach(() => {
+      process.env.GAS_URL = 'https://example.com/gas'
+    })
+
+    it('should default to false when DEFAULT_EXCLUDE_ITEM_TITLE is not set', () => {
+      delete process.env.DEFAULT_EXCLUDE_ITEM_TITLE
+
+      const config = loadConfig()
+
+      expect(config.defaultExcludeItemTitle).toBe(false)
+    })
+
+    it('should be true when DEFAULT_EXCLUDE_ITEM_TITLE is "true"', () => {
+      process.env.DEFAULT_EXCLUDE_ITEM_TITLE = 'true'
+
+      const config = loadConfig()
+
+      expect(config.defaultExcludeItemTitle).toBe(true)
+    })
+
+    it('should be false when DEFAULT_EXCLUDE_ITEM_TITLE is "false"', () => {
+      process.env.DEFAULT_EXCLUDE_ITEM_TITLE = 'false'
+
+      const config = loadConfig()
+
+      expect(config.defaultExcludeItemTitle).toBe(false)
+    })
+
+    it('should be false when DEFAULT_EXCLUDE_ITEM_TITLE is empty string', () => {
+      process.env.DEFAULT_EXCLUDE_ITEM_TITLE = ''
+
+      const config = loadConfig()
+
+      expect(config.defaultExcludeItemTitle).toBe(false)
+    })
+
+    it('should be false when DEFAULT_EXCLUDE_ITEM_TITLE is any other value', () => {
+      process.env.DEFAULT_EXCLUDE_ITEM_TITLE = 'anything'
+
+      const config = loadConfig()
+
+      expect(config.defaultExcludeItemTitle).toBe(false)
+    })
+  })
 })

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,6 +21,7 @@ describe('RSS Translator Bridge API', () => {
       defaultSourceLang: 'auto',
       defaultTargetLang: 'ja',
       defaultExcludeFeedTitle: true,
+      defaultExcludeItemTitle: false,
     })
 
     mockRSSProcessorInstance = {
@@ -46,7 +47,8 @@ describe('RSS Translator Bridge API', () => {
       request: FastifyRequest<{ Querystring: TranslateRequest }>,
       reply: FastifyReply
     ) => {
-      const { url, sourceLang, targetLang, excludeFeedTitle } = request.query
+      const { url, sourceLang, targetLang, excludeFeedTitle, excludeItemTitle } =
+        request.query
 
       if (!url) {
         return reply.code(400).send({
@@ -60,11 +62,16 @@ describe('RSS Translator Bridge API', () => {
           excludeFeedTitle === 'true' ||
           (excludeFeedTitle === undefined && config.defaultExcludeFeedTitle)
 
+        const shouldExcludeItemTitle =
+          excludeItemTitle === 'true' ||
+          (excludeItemTitle === undefined && config.defaultExcludeItemTitle)
+
         const translatedRSS = await rssProcessor.processRSSFeed(
           url,
           sourceLang ?? config.defaultSourceLang ?? 'auto',
           targetLang ?? config.defaultTargetLang ?? 'ja',
-          shouldExcludeFeedTitle
+          shouldExcludeFeedTitle,
+          shouldExcludeItemTitle
         )
 
         if (!translatedRSS) {
@@ -156,7 +163,8 @@ describe('RSS Translator Bridge API', () => {
         'https://example.com/feed.xml',
         'auto',
         'ja',
-        true
+        true,
+        false
       )
     })
 
@@ -175,7 +183,8 @@ describe('RSS Translator Bridge API', () => {
         'https://example.com/feed.xml',
         'en',
         'ko',
-        true
+        true,
+        false
       )
     })
 
@@ -233,7 +242,8 @@ describe('RSS Translator Bridge API', () => {
         'https://example.com/feed with spaces.xml',
         'auto',
         'ja',
-        true
+        true,
+        false
       )
     })
 
@@ -252,6 +262,7 @@ describe('RSS Translator Bridge API', () => {
         'https://example.com/feed.xml',
         'auto',
         'ja',
+        false,
         false
       )
     })
@@ -271,6 +282,87 @@ describe('RSS Translator Bridge API', () => {
         'https://example.com/feed.xml',
         'auto',
         'ja',
+        true,
+        false
+      )
+    })
+
+    it('should use excludeItemTitle parameter when provided as true', async () => {
+      const mockXML = '<rss>translated without item titles</rss>'
+      mockRSSProcessorInstance.processRSSFeed.mockResolvedValue(mockXML)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api?url=https://example.com/feed.xml&excludeItemTitle=true',
+      })
+
+      expect(response.statusCode).toBe(200)
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockRSSProcessorInstance.processRSSFeed).toHaveBeenCalledWith(
+        'https://example.com/feed.xml',
+        'auto',
+        'ja',
+        true,
+        true
+      )
+    })
+
+    it('should use excludeItemTitle parameter when provided as false', async () => {
+      const mockXML = '<rss>translated with item titles</rss>'
+      mockRSSProcessorInstance.processRSSFeed.mockResolvedValue(mockXML)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api?url=https://example.com/feed.xml&excludeItemTitle=false',
+      })
+
+      expect(response.statusCode).toBe(200)
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockRSSProcessorInstance.processRSSFeed).toHaveBeenCalledWith(
+        'https://example.com/feed.xml',
+        'auto',
+        'ja',
+        true,
+        false
+      )
+    })
+
+    it('should default excludeItemTitle to false when not provided', async () => {
+      const mockXML = '<rss>translated with default item title settings</rss>'
+      mockRSSProcessorInstance.processRSSFeed.mockResolvedValue(mockXML)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api?url=https://example.com/feed.xml',
+      })
+
+      expect(response.statusCode).toBe(200)
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockRSSProcessorInstance.processRSSFeed).toHaveBeenCalledWith(
+        'https://example.com/feed.xml',
+        'auto',
+        'ja',
+        true,
+        false
+      )
+    })
+
+    it('should handle both excludeFeedTitle and excludeItemTitle parameters together', async () => {
+      const mockXML = '<rss>translated with custom exclusion settings</rss>'
+      mockRSSProcessorInstance.processRSSFeed.mockResolvedValue(mockXML)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api?url=https://example.com/feed.xml&excludeFeedTitle=false&excludeItemTitle=true',
+      })
+
+      expect(response.statusCode).toBe(200)
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockRSSProcessorInstance.processRSSFeed).toHaveBeenCalledWith(
+        'https://example.com/feed.xml',
+        'auto',
+        'ja',
+        false,
         true
       )
     })

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -47,8 +47,13 @@ describe('RSS Translator Bridge API', () => {
       request: FastifyRequest<{ Querystring: TranslateRequest }>,
       reply: FastifyReply
     ) => {
-      const { url, sourceLang, targetLang, excludeFeedTitle, excludeItemTitle } =
-        request.query
+      const {
+        url,
+        sourceLang,
+        targetLang,
+        excludeFeedTitle,
+        excludeItemTitle,
+      } = request.query
 
       if (!url) {
         return reply.code(400).send({

--- a/src/__tests__/rss-processor.test.ts
+++ b/src/__tests__/rss-processor.test.ts
@@ -434,6 +434,124 @@ describe('RSSProcessor', () => {
         'ja'
       )
     })
+
+    it('should exclude item title translation when excludeItemTitle is true', async () => {
+      mockParserInstance.parseURL.mockResolvedValue(createMockFeed())
+
+      // Note: item titles should NOT be in the translations since excludeItemTitle=true
+      const mockTranslations = new Map([
+        ['feed-description', 'テスト説明'],
+        ['item-0-content', 'アイテム1コンテンツ'],
+        ['item-1-content', '<p>アイテム2コンテンツエンコード</p>'],
+      ])
+      mockTranslatorInstance.translateBatch.mockResolvedValue(mockTranslations)
+
+      const result = await rssProcessor.processRSSFeed(
+        'https://example.com/feed.xml',
+        'en',
+        'ja',
+        true,
+        true
+      )
+
+      expect(result).toBeDefined()
+      expect(result).toContain('Item 1 Title') // original item title kept (not translated)
+      expect(result).toContain('Item 2 Title') // original item title kept (not translated)
+      expect(result).toContain('テスト説明') // description translated
+      expect(result).toContain('アイテム1コンテンツ') // item content translated
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockTranslatorInstance.translateBatch).toHaveBeenCalledWith(
+        expect.not.arrayContaining([
+          { id: 'item-0-title', text: 'Item 1 Title' },
+        ]),
+        'en',
+        'ja'
+      )
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockTranslatorInstance.translateBatch).toHaveBeenCalledWith(
+        expect.not.arrayContaining([
+          { id: 'item-1-title', text: 'Item 2 Title' },
+        ]),
+        'en',
+        'ja'
+      )
+    })
+
+    it('should translate item titles when excludeItemTitle is false (default)', async () => {
+      mockParserInstance.parseURL.mockResolvedValue(createMockFeed())
+
+      // All item titles should be in the translations
+      const mockTranslations = new Map([
+        ['feed-description', 'テスト説明'],
+        ['item-0-title', 'アイテム1タイトル'],
+        ['item-0-content', 'アイテム1コンテンツ'],
+        ['item-1-title', 'アイテム2タイトル'],
+        ['item-1-content', '<p>アイテム2コンテンツエンコード</p>'],
+      ])
+      mockTranslatorInstance.translateBatch.mockResolvedValue(mockTranslations)
+
+      const result = await rssProcessor.processRSSFeed(
+        'https://example.com/feed.xml',
+        'en',
+        'ja',
+        true,
+        false
+      )
+
+      expect(result).toBeDefined()
+      expect(result).toContain('アイテム1タイトル') // item title translated
+      expect(result).toContain('アイテム2タイトル') // item title translated
+      expect(result).toContain('テスト説明') // description translated
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockTranslatorInstance.translateBatch).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          { id: 'item-0-title', text: 'Item 1 Title' },
+          { id: 'item-1-title', text: 'Item 2 Title' },
+        ]),
+        'en',
+        'ja'
+      )
+    })
+
+    it('should handle both excludeFeedTitle and excludeItemTitle together', async () => {
+      mockParserInstance.parseURL.mockResolvedValue(createMockFeed())
+
+      // Only content should be translated (no feed title, no item titles)
+      const mockTranslations = new Map([
+        ['feed-description', 'テスト説明'],
+        ['item-0-content', 'アイテム1コンテンツ'],
+        ['item-1-content', '<p>アイテム2コンテンツエンコード</p>'],
+      ])
+      mockTranslatorInstance.translateBatch.mockResolvedValue(mockTranslations)
+
+      const result = await rssProcessor.processRSSFeed(
+        'https://example.com/feed.xml',
+        'en',
+        'ja',
+        true,
+        true
+      )
+
+      expect(result).toBeDefined()
+      expect(result).toContain('Test Feed') // original feed title kept
+      expect(result).toContain('Item 1 Title') // original item title kept
+      expect(result).toContain('Item 2 Title') // original item title kept
+      expect(result).toContain('テスト説明') // description translated
+      expect(result).toContain('アイテム1コンテンツ') // item content translated
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockTranslatorInstance.translateBatch).toHaveBeenCalledWith(
+        expect.not.arrayContaining([
+          { id: 'feed-title', text: 'Test Feed' },
+          { id: 'item-0-title', text: 'Item 1 Title' },
+          { id: 'item-1-title', text: 'Item 2 Title' },
+        ]),
+        'en',
+        'ja'
+      )
+    })
   })
 
   describe('feedToXML', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,5 +13,6 @@ export function loadConfig(): Config {
     defaultSourceLang: process.env.DEFAULT_SOURCE_LANG ?? 'auto',
     defaultTargetLang: process.env.DEFAULT_TARGET_LANG ?? 'ja',
     defaultExcludeFeedTitle: process.env.DEFAULT_EXCLUDE_FEED_TITLE !== 'false',
+    defaultExcludeItemTitle: process.env.DEFAULT_EXCLUDE_ITEM_TITLE === 'true',
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,8 @@ export async function getApp() {
     request: FastifyRequest<{ Querystring: TranslateRequest }>,
     reply: FastifyReply
   ) => {
-    const { url, sourceLang, targetLang, excludeFeedTitle } = request.query
+    const { url, sourceLang, targetLang, excludeFeedTitle, excludeItemTitle } =
+      request.query
 
     if (!url) {
       const response: TranslateResponse = {
@@ -85,11 +86,16 @@ export async function getApp() {
         excludeFeedTitle === 'true' ||
         (excludeFeedTitle === undefined && config.defaultExcludeFeedTitle)
 
+      const shouldExcludeItemTitle =
+        excludeItemTitle === 'true' ||
+        (excludeItemTitle === undefined && config.defaultExcludeItemTitle)
+
       const translatedRSS = await rssProcessor.processRSSFeed(
         url,
         sourceLang ?? config.defaultSourceLang ?? 'auto',
         targetLang ?? config.defaultTargetLang ?? 'ja',
-        shouldExcludeFeedTitle
+        shouldExcludeFeedTitle,
+        shouldExcludeItemTitle
       )
 
       if (!translatedRSS) {

--- a/src/rss-processor.ts
+++ b/src/rss-processor.ts
@@ -20,7 +20,8 @@ export class RSSProcessor {
     feedUrl: string,
     sourceLang: string,
     targetLang: string,
-    excludeFeedTitle = true
+    excludeFeedTitle = true,
+    excludeItemTitle = false
   ): Promise<string | null> {
     try {
       // Fetch and parse RSS feed
@@ -41,7 +42,7 @@ export class RSSProcessor {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (feed.items?.length) {
         for (const [index, item] of feed.items.entries()) {
-          if (item.title) {
+          if (item.title && !excludeItemTitle) {
             batchItems.push({ id: `item-${index}-title`, text: item.title })
           }
 
@@ -81,7 +82,7 @@ export class RSSProcessor {
           const titleKey = `item-${index}-title`
           const contentKey = `item-${index}-content`
 
-          if (item.title && translations.has(titleKey)) {
+          if (item.title && !excludeItemTitle && translations.has(titleKey)) {
             item.title = translations.get(titleKey) ?? item.title
           }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Config {
   defaultSourceLang?: string
   defaultTargetLang?: string
   defaultExcludeFeedTitle?: boolean
+  defaultExcludeItemTitle?: boolean
 }
 
 export interface TranslateRequest {
@@ -12,6 +13,7 @@ export interface TranslateRequest {
   sourceLang?: string
   targetLang?: string
   excludeFeedTitle?: string
+  excludeItemTitle?: string
 }
 
 export interface TranslateResponse {


### PR DESCRIPTION
## 概要

Issue #22 に対応し、RSS フィードの記事タイトルを翻訳しないオプション (`excludeItemTitle`) を追加しました。

## 変更内容

### 機能追加

- **`excludeItemTitle` クエリパラメータ**: 記事タイトルの翻訳を制御
  - `true`: 記事タイトルを翻訳せず、元のタイトルを保持
  - `false` (デフォルト): 記事タイトルを翻訳
- **`DEFAULT_EXCLUDE_ITEM_TITLE` 環境変数**: デフォルト動作を設定
  - `true`: デフォルトで記事タイトルを翻訳しない
  - デフォルト値は `false` (記事タイトルを翻訳する)

### 変更されたファイル

#### コア実装
- **src/types.ts**: `Config` と `TranslateRequest` インターフェースに `excludeItemTitle` 関連フィールドを追加
- **src/config.ts**: `DEFAULT_EXCLUDE_ITEM_TITLE` 環境変数の読み込み処理を追加
- **src/index.ts**: `excludeItemTitle` クエリパラメータの処理と `processRSSFeed` への引き渡しを実装
- **src/rss-processor.ts**: `processRSSFeed` メソッドに `excludeItemTitle` パラメータを追加し、記事タイトルの翻訳スキップロジックを実装

#### ドキュメント
- **CLAUDE.md**: 環境変数セクションに `DEFAULT_EXCLUDE_ITEM_TITLE` を追加、API 仕様セクションに `excludeItemTitle` パラメータを追加
- **.env.example**: 翻訳除外設定の例を追加 (`DEFAULT_EXCLUDE_FEED_TITLE` と `DEFAULT_EXCLUDE_ITEM_TITLE`)

#### ウェブUI
- **public/index.html**: 記事タイトル翻訳除外チェックボックスを追加
- **public/script.js**: `excludeItemTitle` チェックボックスの値を取得し、API リクエストパラメータに含める処理を追加

#### テスト
- **src/__tests__/config.test.ts**: `defaultExcludeItemTitle` の動作確認テストを 5 件追加
- **src/__tests__/index.test.ts**: `excludeItemTitle` パラメータの処理確認テストを 4 件追加
- **src/__tests__/rss-processor.test.ts**: `excludeItemTitle` による翻訳スキップ動作確認テストを 3 件追加

## 実装詳細

Issue #19 で実装された `excludeFeedTitle` オプションと同様のアプローチを採用:

1. **クエリパラメータ優先**: 明示的に指定された場合はその値を使用
2. **環境変数フォールバック**: クエリパラメータ未指定時は環境変数のデフォルト値を使用
3. **バッチ翻訳除外**: `excludeItemTitle` が `true` の場合、記事タイトルを翻訳対象から除外
4. **翻訳結果適用スキップ**: 同じ条件で翻訳結果の適用もスキップ

## デフォルト値の設計思想

- **`defaultExcludeFeedTitle`**: デフォルト `true` (フィードタイトルは翻訳しない)
- **`defaultExcludeItemTitle`**: デフォルト `false` (記事タイトルは翻訳する)

この非対称な設計により、ユーザーは記事の内容を翻訳された状態で読めるため、UX が向上します。

## テスト結果

- ✅ `pnpm lint`: Prettier、ESLint、TypeScript 型チェック成功
- ✅ `pnpm test`: 全 84 テスト成功（12 件の新規テストを含む）
- ✅ GitHub Actions CI: Node CI、Vercel デプロイメント成功
- ✅ コードレビュー: 信頼度スコア 80 以上の指摘事項なし

## 関連 Issue

Closes #22

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)