### PR TITLE
feat: 翻訳キャッシュと CDN キャッシュを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,13 @@ DEFAULT_TARGET_LANG=ja
 # Translation Exclusion Settings (Optional)
 # DEFAULT_EXCLUDE_FEED_TITLE=true  # Exclude RSS feed title from translation (default: true)
 # DEFAULT_EXCLUDE_ITEM_TITLE=false # Exclude RSS item titles from translation (default: false)
+
+# Translation Cache Settings (Optional)
+TRANSLATION_CACHE_ENABLED=true
+TRANSLATION_CACHE_TTL_MS=21600000
+TRANSLATION_CACHE_MAX_ITEMS=1000
+
+# CDN Cache Settings (Optional)
+CDN_CACHE_ENABLED=true
+CDN_CACHE_S_MAXAGE=300
+CDN_CACHE_STALE_WHILE_REVALIDATE=60

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,12 @@ pnpm typecheck
 - `DEFAULT_TARGET_LANG`: デフォルトターゲット言語（デフォルト: ja）
 - `DEFAULT_EXCLUDE_FEED_TITLE`: RSS フィードタイトルを翻訳しないかどうか（デフォルト: true）
 - `DEFAULT_EXCLUDE_ITEM_TITLE`: RSS 記事タイトルを翻訳しないかどうか（デフォルト: false）
+- `TRANSLATION_CACHE_ENABLED`: 翻訳キャッシュを有効にするかどうか（デフォルト: true）
+- `TRANSLATION_CACHE_TTL_MS`: 翻訳キャッシュの TTL (ミリ秒)（デフォルト: 21600000）
+- `TRANSLATION_CACHE_MAX_ITEMS`: 翻訳キャッシュの最大件数（デフォルト: 1000）
+- `CDN_CACHE_ENABLED`: CDN キャッシュを有効にするかどうか（デフォルト: true）
+- `CDN_CACHE_S_MAXAGE`: CDN キャッシュの TTL (秒)（デフォルト: 300）
+- `CDN_CACHE_STALE_WHILE_REVALIDATE`: CDN 再検証の猶予時間 (秒)（デフォルト: 60）
 
 ## セキュリティ / 機密情報
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,21 @@ Google Translate API がサポートする全ての言語に対応：
 
 ### 環境変数
 
-| 変数名                | 必須 | 説明                               | デフォルト |
-| --------------------- | ---- | ---------------------------------- | ---------- |
-| `GAS_URL`             | ✅   | Google Apps Script 翻訳 API の URL | -          |
-| `PORT`                | ❌   | サーバーポート                     | `3000`     |
-| `HOST`                | ❌   | サーバーホスト                     | `0.0.0.0`  |
-| `DEFAULT_SOURCE_LANG` | ❌   | デフォルトソース言語               | `auto`     |
-| `DEFAULT_TARGET_LANG` | ❌   | デフォルトターゲット言語           | `ja`       |
+| 変数名                             | 必須 | 説明                               | デフォルト |
+| ---------------------------------- | ---- | ---------------------------------- | ---------- |
+| `GAS_URL`                          | ✅   | Google Apps Script 翻訳 API の URL | -          |
+| `PORT`                             | ❌   | サーバーポート                     | `3000`     |
+| `HOST`                             | ❌   | サーバーホスト                     | `0.0.0.0`  |
+| `DEFAULT_SOURCE_LANG`              | ❌   | デフォルトソース言語               | `auto`     |
+| `DEFAULT_TARGET_LANG`              | ❌   | デフォルトターゲット言語           | `ja`       |
+| `DEFAULT_EXCLUDE_FEED_TITLE`       | ❌   | RSS フィードタイトルを翻訳しない   | `true`     |
+| `DEFAULT_EXCLUDE_ITEM_TITLE`       | ❌   | RSS 記事タイトルを翻訳しない       | `false`    |
+| `TRANSLATION_CACHE_ENABLED`        | ❌   | 翻訳キャッシュを有効にする         | `true`     |
+| `TRANSLATION_CACHE_TTL_MS`         | ❌   | 翻訳キャッシュの TTL (ms)          | `21600000` |
+| `TRANSLATION_CACHE_MAX_ITEMS`      | ❌   | 翻訳キャッシュの最大件数           | `1000`     |
+| `CDN_CACHE_ENABLED`                | ❌   | CDN キャッシュを有効にする         | `true`     |
+| `CDN_CACHE_S_MAXAGE`               | ❌   | CDN キャッシュの TTL (秒)          | `300`      |
+| `CDN_CACHE_STALE_WHILE_REVALIDATE` | ❌   | CDN 再検証の猶予時間 (秒)          | `60`       |
 
 ### 開発コマンド
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -23,6 +23,16 @@ describe('loadConfig', () => {
     expect(config.defaultSourceLang).toBe('auto')
     expect(config.defaultTargetLang).toBe('ja')
     expect(config.defaultExcludeFeedTitle).toBe(true)
+    expect(config.translationCache).toEqual({
+      enabled: true,
+      ttlMs: 21_600_000,
+      maxItems: 1000,
+    })
+    expect(config.cacheControl).toEqual({
+      enabled: true,
+      sMaxAge: 300,
+      staleWhileRevalidate: 60,
+    })
   })
 
   it('should throw error when GAS_URL is not set', () => {
@@ -40,6 +50,12 @@ describe('loadConfig', () => {
     process.env.DEFAULT_SOURCE_LANG = 'en'
     process.env.DEFAULT_TARGET_LANG = 'ko'
     process.env.DEFAULT_EXCLUDE_FEED_TITLE = 'false'
+    process.env.TRANSLATION_CACHE_ENABLED = 'false'
+    process.env.TRANSLATION_CACHE_TTL_MS = '7200000'
+    process.env.TRANSLATION_CACHE_MAX_ITEMS = '500'
+    process.env.CDN_CACHE_ENABLED = 'false'
+    process.env.CDN_CACHE_S_MAXAGE = '120'
+    process.env.CDN_CACHE_STALE_WHILE_REVALIDATE = '30'
 
     const config = loadConfig()
 
@@ -48,6 +64,16 @@ describe('loadConfig', () => {
     expect(config.defaultSourceLang).toBe('en')
     expect(config.defaultTargetLang).toBe('ko')
     expect(config.defaultExcludeFeedTitle).toBe(false)
+    expect(config.translationCache).toEqual({
+      enabled: false,
+      ttlMs: 7_200_000,
+      maxItems: 500,
+    })
+    expect(config.cacheControl).toEqual({
+      enabled: false,
+      sMaxAge: 120,
+      staleWhileRevalidate: 30,
+    })
   })
 
   it('should handle invalid PORT environment variable', () => {
@@ -65,6 +91,10 @@ describe('loadConfig', () => {
     process.env.HOST = ''
     process.env.DEFAULT_SOURCE_LANG = ''
     process.env.DEFAULT_TARGET_LANG = ''
+    process.env.TRANSLATION_CACHE_TTL_MS = ''
+    process.env.TRANSLATION_CACHE_MAX_ITEMS = ''
+    process.env.CDN_CACHE_S_MAXAGE = ''
+    process.env.CDN_CACHE_STALE_WHILE_REVALIDATE = ''
 
     const config = loadConfig()
 
@@ -72,6 +102,10 @@ describe('loadConfig', () => {
     expect(config.host).toBe('') // empty string, not fallback
     expect(config.defaultSourceLang).toBe('') // empty string, not fallback
     expect(config.defaultTargetLang).toBe('') // empty string, not fallback
+    expect(config.translationCache.ttlMs).toBeNaN()
+    expect(config.translationCache.maxItems).toBeNaN()
+    expect(config.cacheControl.sMaxAge).toBeNaN()
+    expect(config.cacheControl.staleWhileRevalidate).toBeNaN()
   })
 
   it('should handle zero PORT value', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 import fastify, { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { loadConfig } from '../config'
 import { RSSProcessor } from '../rss-processor'
-import { TranslateRequest } from '../types'
+import { Config, TranslateRequest } from '../types'
+import { buildCacheControlHeader } from '../cache-control'
 
 jest.mock('../config')
 jest.mock('../rss-processor')
@@ -13,37 +14,9 @@ describe('RSS Translator Bridge API', () => {
   let app: FastifyInstance
   let mockRSSProcessorInstance: jest.Mocked<RSSProcessor>
 
-  beforeEach(async () => {
-    mockLoadConfig.mockReturnValue({
-      gasUrl: 'https://example.com/gas',
-      port: 3000,
-      host: '0.0.0.0',
-      defaultSourceLang: 'auto',
-      defaultTargetLang: 'ja',
-      defaultExcludeFeedTitle: true,
-      defaultExcludeItemTitle: false,
-      translationCache: {
-        enabled: true,
-        ttlMs: 21_600_000,
-        maxItems: 1000,
-      },
-      cacheControl: {
-        enabled: true,
-        sMaxAge: 300,
-        staleWhileRevalidate: 60,
-      },
-    })
-
-    mockRSSProcessorInstance = {
-      processRSSFeed: jest.fn(),
-    } as any
-
-    mockRSSProcessor.mockImplementation(() => mockRSSProcessorInstance)
-
-    // Create a simplified test app with same logic
-    const config = mockLoadConfig()
-    app = fastify({ logger: false })
-    await app.register(import('@fastify/cors'), { origin: true })
+  const createTestApp = async (config: Config) => {
+    const testApp = fastify({ logger: false })
+    await testApp.register(import('@fastify/cors'), { origin: true })
 
     const rssProcessor = new RSSProcessor(
       config.gasUrl,
@@ -51,7 +24,7 @@ describe('RSS Translator Bridge API', () => {
     )
 
     // Health check endpoint
-    app.get('/health', () => {
+    testApp.get('/health', () => {
       return { status: 'ok', timestamp: new Date().toISOString() }
     })
 
@@ -102,10 +75,7 @@ describe('RSS Translator Bridge API', () => {
         return await reply
           .code(200)
           .header('Content-Type', 'application/rss+xml; charset=utf-8')
-          .header(
-            'Cache-Control',
-            'public, max-age=0, s-maxage=300, stale-while-revalidate=60'
-          )
+          .header('Cache-Control', buildCacheControlHeader(config.cacheControl))
           .send(translatedRSS)
       } catch {
         return await reply.code(500).send({
@@ -116,9 +86,41 @@ describe('RSS Translator Bridge API', () => {
     }
 
     // Register API route
-    app.get('/api', translateHandler)
+    testApp.get('/api', translateHandler)
 
-    await app.ready()
+    await testApp.ready()
+    return testApp
+  }
+
+  beforeEach(async () => {
+    mockLoadConfig.mockReturnValue({
+      gasUrl: 'https://example.com/gas',
+      port: 3000,
+      host: '0.0.0.0',
+      defaultSourceLang: 'auto',
+      defaultTargetLang: 'ja',
+      defaultExcludeFeedTitle: true,
+      defaultExcludeItemTitle: false,
+      translationCache: {
+        enabled: true,
+        ttlMs: 21_600_000,
+        maxItems: 1000,
+      },
+      cacheControl: {
+        enabled: true,
+        sMaxAge: 300,
+        staleWhileRevalidate: 60,
+      },
+    })
+
+    mockRSSProcessorInstance = {
+      processRSSFeed: jest.fn(),
+    } as any
+
+    mockRSSProcessor.mockImplementation(() => mockRSSProcessorInstance)
+
+    const config = mockLoadConfig()
+    app = await createTestApp(config)
     jest.clearAllMocks()
   })
 
@@ -180,7 +182,7 @@ describe('RSS Translator Bridge API', () => {
         'application/rss+xml; charset=utf-8'
       )
       expect(response.headers['cache-control']).toBe(
-        'public, max-age=0, s-maxage=300, stale-while-revalidate=60'
+        buildCacheControlHeader(mockLoadConfig().cacheControl)
       )
       expect(response.body).toBe(mockXML)
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -211,6 +213,40 @@ describe('RSS Translator Bridge API', () => {
         true,
         false
       )
+    })
+
+    it('should return no-store when CDN cache is disabled', async () => {
+      const mockXML = '<rss>cache disabled</rss>'
+      mockRSSProcessorInstance.processRSSFeed.mockResolvedValue(mockXML)
+      await app.close()
+      mockLoadConfig.mockReturnValue({
+        gasUrl: 'https://example.com/gas',
+        port: 3000,
+        host: '0.0.0.0',
+        defaultSourceLang: 'auto',
+        defaultTargetLang: 'ja',
+        defaultExcludeFeedTitle: true,
+        defaultExcludeItemTitle: false,
+        translationCache: {
+          enabled: true,
+          ttlMs: 21_600_000,
+          maxItems: 1000,
+        },
+        cacheControl: {
+          enabled: false,
+          sMaxAge: 300,
+          staleWhileRevalidate: 60,
+        },
+      })
+      app = await createTestApp(mockLoadConfig())
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api?url=https://example.com/feed.xml',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['cache-control']).toBe('no-store')
     })
 
     it('should return 500 when RSS processing fails', async () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -22,6 +22,16 @@ describe('RSS Translator Bridge API', () => {
       defaultTargetLang: 'ja',
       defaultExcludeFeedTitle: true,
       defaultExcludeItemTitle: false,
+      translationCache: {
+        enabled: true,
+        ttlMs: 21_600_000,
+        maxItems: 1000,
+      },
+      cacheControl: {
+        enabled: true,
+        sMaxAge: 300,
+        staleWhileRevalidate: 60,
+      },
     })
 
     mockRSSProcessorInstance = {
@@ -35,7 +45,10 @@ describe('RSS Translator Bridge API', () => {
     app = fastify({ logger: false })
     await app.register(import('@fastify/cors'), { origin: true })
 
-    const rssProcessor = new RSSProcessor(config.gasUrl)
+    const rssProcessor = new RSSProcessor(
+      config.gasUrl,
+      config.translationCache
+    )
 
     // Health check endpoint
     app.get('/health', () => {
@@ -89,6 +102,10 @@ describe('RSS Translator Bridge API', () => {
         return await reply
           .code(200)
           .header('Content-Type', 'application/rss+xml; charset=utf-8')
+          .header(
+            'Cache-Control',
+            'public, max-age=0, s-maxage=300, stale-while-revalidate=60'
+          )
           .send(translatedRSS)
       } catch {
         return await reply.code(500).send({
@@ -161,6 +178,9 @@ describe('RSS Translator Bridge API', () => {
       expect(response.statusCode).toBe(200)
       expect(response.headers['content-type']).toBe(
         'application/rss+xml; charset=utf-8'
+      )
+      expect(response.headers['cache-control']).toBe(
+        'public, max-age=0, s-maxage=300, stale-while-revalidate=60'
       )
       expect(response.body).toBe(mockXML)
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/__tests__/startup.test.ts
+++ b/src/__tests__/startup.test.ts
@@ -21,7 +21,7 @@ async function getTestApp() {
 
   // staticプラグインはテスト環境では登録しない
 
-  const rssProcessor = new RSSProcessor(config.gasUrl)
+  const rssProcessor = new RSSProcessor(config.gasUrl, config.translationCache)
 
   // Health check endpoint
   app.get('/health', () => {
@@ -90,6 +90,10 @@ async function getTestApp() {
       return await reply
         .code(200)
         .header('Content-Type', 'application/rss+xml; charset=utf-8')
+        .header(
+          'Cache-Control',
+          `public, max-age=0, s-maxage=${config.cacheControl.sMaxAge}, stale-while-revalidate=${config.cacheControl.staleWhileRevalidate}`
+        )
         .send(translatedRSS)
     } catch (error) {
       app.log.error(error)

--- a/src/__tests__/startup.test.ts
+++ b/src/__tests__/startup.test.ts
@@ -3,6 +3,7 @@ import cors from '@fastify/cors'
 import { loadConfig } from '../config.js'
 import { RSSProcessor } from '../rss-processor.js'
 import { TranslateRequest, TranslateResponse } from '../types.js'
+import { buildCacheControlHeader } from '../cache-control.js'
 
 // 起動テスト用の設定を追加
 process.env.NODE_ENV = 'test'
@@ -90,10 +91,7 @@ async function getTestApp() {
       return await reply
         .code(200)
         .header('Content-Type', 'application/rss+xml; charset=utf-8')
-        .header(
-          'Cache-Control',
-          `public, max-age=0, s-maxage=${config.cacheControl.sMaxAge}, stale-while-revalidate=${config.cacheControl.staleWhileRevalidate}`
-        )
+        .header('Cache-Control', buildCacheControlHeader(config.cacheControl))
         .send(translatedRSS)
     } catch (error) {
       app.log.error(error)

--- a/src/__tests__/translation-cache.test.ts
+++ b/src/__tests__/translation-cache.test.ts
@@ -1,0 +1,39 @@
+import { TranslationCache } from '../translation-cache'
+
+describe('TranslationCache', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('should return null when cache entry is expired', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    const cache = new TranslationCache({
+      enabled: true,
+      ttlMs: 1000,
+      maxItems: 10,
+    })
+
+    cache.set('key', 'value')
+    jest.setSystemTime(new Date('2026-01-01T00:00:01.001Z'))
+
+    expect(cache.get('key')).toBeNull()
+  })
+
+  it('should evict oldest entry when maxItems is exceeded', () => {
+    const cache = new TranslationCache({
+      enabled: true,
+      ttlMs: 10_000,
+      maxItems: 2,
+    })
+
+    cache.set('first', '1')
+    cache.set('second', '2')
+    cache.get('first')
+    cache.set('third', '3')
+
+    expect(cache.get('second')).toBeNull()
+    expect(cache.get('first')).toBe('1')
+    expect(cache.get('third')).toBe('3')
+  })
+})

--- a/src/__tests__/translation-cache.test.ts
+++ b/src/__tests__/translation-cache.test.ts
@@ -36,4 +36,18 @@ describe('TranslationCache', () => {
     expect(cache.get('first')).toBe('1')
     expect(cache.get('third')).toBe('3')
   })
+
+  it('should evict even when oldest key is empty string', () => {
+    const cache = new TranslationCache({
+      enabled: true,
+      ttlMs: 10_000,
+      maxItems: 1,
+    })
+
+    cache.set('', 'empty')
+    cache.set('next', 'value')
+
+    expect(cache.get('')).toBeNull()
+    expect(cache.get('next')).toBe('value')
+  })
 })

--- a/src/__tests__/translator.test.ts
+++ b/src/__tests__/translator.test.ts
@@ -44,6 +44,32 @@ describe('Translator', () => {
     )
   })
 
+  it('should reuse cached translation on repeated calls', async () => {
+    translator = new Translator('https://example.com/translate', {
+      enabled: true,
+      ttlMs: 60_000,
+      maxItems: 100,
+    })
+    const mockResponse = {
+      status: 200,
+      data: {
+        response: {
+          status: true,
+          result: 'こんにちは',
+        },
+      },
+    }
+    mockedAxios.post.mockResolvedValueOnce(mockResponse)
+
+    const first = await translator.translate('Hello', 'en', 'ja')
+    const second = await translator.translate('Hello', 'en', 'ja')
+
+    expect(first).toBe('こんにちは')
+    expect(second).toBe('こんにちは')
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1)
+  })
+
   it('should return null on translation error', async () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {
       // no-op
@@ -217,35 +243,11 @@ describe('Translator - Batch Translation', () => {
   })
 
   it('should handle empty batch items', async () => {
-    const mockResponse = {
-      status: 200,
-      data: {
-        status: true,
-        processed: 0,
-        total: 0,
-        executionTime: 10,
-        results: [],
-      },
-    }
-    mockedAxios.post.mockResolvedValueOnce(mockResponse)
-
     const result = await translator.translateBatch([], 'en', 'ja')
 
     expect(result.size).toBe(0)
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(mockedAxios.post).toHaveBeenCalledWith(
-      'https://example.com/translate',
-      {
-        batch: true,
-        before: 'en',
-        after: 'ja',
-        texts: [],
-        mode: 'html',
-      },
-      expect.objectContaining({
-        timeout: 25_000,
-      })
-    )
+    expect(mockedAxios.post).not.toHaveBeenCalled()
   })
 
   it('should return original texts on network error', async () => {
@@ -362,5 +364,54 @@ describe('Translator - Batch Translation', () => {
     expect(result.size).toBe(100)
     expect(result.get('item0')).toBe('翻訳 Text 0')
     expect(result.get('item99')).toBe('翻訳 Text 99')
+  })
+
+  it('should use cached batch results on repeated calls', async () => {
+    translator = new Translator('https://example.com/translate', {
+      enabled: true,
+      ttlMs: 60_000,
+      maxItems: 100,
+    })
+    const mockResponse = {
+      status: 200,
+      data: {
+        status: true,
+        processed: 3,
+        total: 3,
+        executionTime: 500,
+        results: [
+          {
+            id: 'item1',
+            success: true,
+            original: 'Hello',
+            translated: 'こんにちは',
+          },
+          { id: 'item2', success: true, original: 'World', translated: '世界' },
+          {
+            id: 'item3',
+            success: true,
+            original: 'How are you?',
+            translated: '元気ですか？',
+          },
+        ],
+      },
+    }
+    mockedAxios.post.mockResolvedValueOnce(mockResponse)
+
+    const first = await translator.translateBatch(mockBatchItems, 'en', 'ja')
+
+    expect(first.get('item1')).toBe('こんにちは')
+    expect(first.get('item2')).toBe('世界')
+    expect(first.get('item3')).toBe('元気ですか？')
+
+    mockedAxios.post.mockClear()
+
+    const second = await translator.translateBatch(mockBatchItems, 'en', 'ja')
+
+    expect(second.get('item1')).toBe('こんにちは')
+    expect(second.get('item2')).toBe('世界')
+    expect(second.get('item3')).toBe('元気ですか？')
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockedAxios.post).not.toHaveBeenCalled()
   })
 })

--- a/src/cache-control.ts
+++ b/src/cache-control.ts
@@ -1,0 +1,25 @@
+import { CacheControlConfig } from './types.js'
+
+/** Cache-Control の秒数を正規化する。 */
+function normalizeCacheSeconds(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0
+  }
+  return Math.floor(value)
+}
+
+/** Cache-Control ヘッダーを生成する。 */
+export function buildCacheControlHeader(
+  cacheControl: CacheControlConfig
+): string {
+  if (!cacheControl.enabled) {
+    return 'no-store'
+  }
+
+  const sMaxAge = normalizeCacheSeconds(cacheControl.sMaxAge)
+  const staleWhileRevalidate = normalizeCacheSeconds(
+    cacheControl.staleWhileRevalidate
+  )
+
+  return `public, max-age=0, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,32 @@
 import { Config } from './types.js'
 
+/** 環境変数から設定を読み込む。 */
 export function loadConfig(): Config {
   const gasUrl = process.env.GAS_URL
   if (!gasUrl) {
     throw new Error('GAS_URL environment variable is required')
   }
+
+  const translationCacheEnabled =
+    process.env.TRANSLATION_CACHE_ENABLED !== 'false'
+  const translationCacheTtlMs = Number.parseInt(
+    process.env.TRANSLATION_CACHE_TTL_MS ?? '21600000',
+    10
+  )
+  const translationCacheMaxItems = Number.parseInt(
+    process.env.TRANSLATION_CACHE_MAX_ITEMS ?? '1000',
+    10
+  )
+
+  const cacheControlEnabled = process.env.CDN_CACHE_ENABLED !== 'false'
+  const cacheControlSMaxAge = Number.parseInt(
+    process.env.CDN_CACHE_S_MAXAGE ?? '300',
+    10
+  )
+  const cacheControlStaleWhileRevalidate = Number.parseInt(
+    process.env.CDN_CACHE_STALE_WHILE_REVALIDATE ?? '60',
+    10
+  )
 
   return {
     gasUrl,
@@ -14,5 +36,15 @@ export function loadConfig(): Config {
     defaultTargetLang: process.env.DEFAULT_TARGET_LANG ?? 'ja',
     defaultExcludeFeedTitle: process.env.DEFAULT_EXCLUDE_FEED_TITLE !== 'false',
     defaultExcludeItemTitle: process.env.DEFAULT_EXCLUDE_ITEM_TITLE === 'true',
+    translationCache: {
+      enabled: translationCacheEnabled,
+      ttlMs: translationCacheTtlMs,
+      maxItems: translationCacheMaxItems,
+    },
+    cacheControl: {
+      enabled: cacheControlEnabled,
+      sMaxAge: cacheControlSMaxAge,
+      staleWhileRevalidate: cacheControlStaleWhileRevalidate,
+    },
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,36 +5,11 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { loadConfig } from './config.js'
 import { RSSProcessor } from './rss-processor.js'
-import {
-  CacheControlConfig,
-  TranslateRequest,
-  TranslateResponse,
-} from './types.js'
+import { buildCacheControlHeader } from './cache-control.js'
+import { TranslateRequest, TranslateResponse } from './types.js'
 
 const currentFilename = fileURLToPath(import.meta.url)
 const currentDirname = path.dirname(currentFilename)
-
-/** Cache-Control の秒数を正規化する。 */
-function normalizeCacheSeconds(value: number): number {
-  if (!Number.isFinite(value) || value <= 0) {
-    return 0
-  }
-  return Math.floor(value)
-}
-
-/** Cache-Control ヘッダーを生成する。 */
-function buildCacheControlHeader(cacheControl: CacheControlConfig): string {
-  if (!cacheControl.enabled) {
-    return 'no-store'
-  }
-
-  const sMaxAge = normalizeCacheSeconds(cacheControl.sMaxAge)
-  const staleWhileRevalidate = normalizeCacheSeconds(
-    cacheControl.staleWhileRevalidate
-  )
-
-  return `public, max-age=0, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`
-}
 
 /** Fastify アプリケーションを生成する。 */
 export async function getApp() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,38 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { loadConfig } from './config.js'
 import { RSSProcessor } from './rss-processor.js'
-import { TranslateRequest, TranslateResponse } from './types.js'
+import {
+  CacheControlConfig,
+  TranslateRequest,
+  TranslateResponse,
+} from './types.js'
 
 const currentFilename = fileURLToPath(import.meta.url)
 const currentDirname = path.dirname(currentFilename)
 
+/** Cache-Control の秒数を正規化する。 */
+function normalizeCacheSeconds(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0
+  }
+  return Math.floor(value)
+}
+
+/** Cache-Control ヘッダーを生成する。 */
+function buildCacheControlHeader(cacheControl: CacheControlConfig): string {
+  if (!cacheControl.enabled) {
+    return 'no-store'
+  }
+
+  const sMaxAge = normalizeCacheSeconds(cacheControl.sMaxAge)
+  const staleWhileRevalidate = normalizeCacheSeconds(
+    cacheControl.staleWhileRevalidate
+  )
+
+  return `public, max-age=0, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`
+}
+
+/** Fastify アプリケーションを生成する。 */
 export async function getApp() {
   const config = loadConfig()
   const app = fastify({
@@ -29,7 +56,7 @@ export async function getApp() {
     })
   }
 
-  const rssProcessor = new RSSProcessor(config.gasUrl)
+  const rssProcessor = new RSSProcessor(config.gasUrl, config.translationCache)
 
   // Health check endpoint
   app.get('/health', () => {
@@ -66,6 +93,7 @@ export async function getApp() {
   })
 
   // Main RSS translation endpoint handler
+  /** RSS 翻訳 API を処理する。 */
   const translateHandler = async (
     request: FastifyRequest<{ Querystring: TranslateRequest }>,
     reply: FastifyReply
@@ -110,6 +138,7 @@ export async function getApp() {
       return await reply
         .code(200)
         .header('Content-Type', 'application/rss+xml; charset=utf-8')
+        .header('Cache-Control', buildCacheControlHeader(config.cacheControl))
         .send(translatedRSS)
     } catch (error) {
       app.log.error(error)
@@ -129,6 +158,7 @@ export async function getApp() {
   return app
 }
 
+/** サーバーを起動する。 */
 async function start() {
   const config = loadConfig()
   const app = await getApp()

--- a/src/rss-processor.ts
+++ b/src/rss-processor.ts
@@ -1,21 +1,29 @@
 import RSSParser from 'rss-parser'
 import xml2js from 'xml2js'
 import { Translator } from './translator.js'
-import { RSSFeed, RSSItem, RSSObject, BatchTranslateItem } from './types.js'
+import {
+  RSSFeed,
+  RSSItem,
+  RSSObject,
+  BatchTranslateItem,
+  TranslationCacheConfig,
+} from './types.js'
 
 export class RSSProcessor {
   private parser: RSSParser
   private translator: Translator
 
-  constructor(gasUrl: string) {
+  /** RSS 処理クラスを初期化する。 */
+  constructor(gasUrl: string, cacheConfig?: TranslationCacheConfig) {
     this.parser = new RSSParser({
       customFields: {
         item: [['content:encoded', 'contentEncoded']],
       },
     })
-    this.translator = new Translator(gasUrl)
+    this.translator = new Translator(gasUrl, cacheConfig)
   }
 
+  /** RSS フィードを翻訳し、XML として返す。 */
   async processRSSFeed(
     feedUrl: string,
     sourceLang: string,
@@ -115,6 +123,7 @@ export class RSSProcessor {
     }
   }
 
+  /** RSS オブジェクトを XML 文字列へ変換する。 */
   private feedToXML(feed: RSSParser.Output<RSSItem>): string {
     const feedData = feed as RSSFeed
     const rssObject: RSSObject = {

--- a/src/translation-cache.ts
+++ b/src/translation-cache.ts
@@ -1,0 +1,81 @@
+import { TranslationCacheConfig } from './types.js'
+
+/** 翻訳キャッシュのエントリー。 */
+interface CacheEntry {
+  value: string
+  expiresAt: number
+}
+
+/** 翻訳結果を保持する LRU キャッシュ。 */
+export class TranslationCache {
+  private store = new Map<string, CacheEntry>()
+
+  /** 翻訳キャッシュを初期化する。 */
+  constructor(private config: TranslationCacheConfig) {}
+
+  /** キャッシュから翻訳結果を取得する。 */
+  get(key: string): string | null {
+    if (!this.config.enabled) {
+      return null
+    }
+    if (
+      !Number.isFinite(this.config.ttlMs) ||
+      !Number.isFinite(this.config.maxItems)
+    ) {
+      return null
+    }
+
+    const entry = this.store.get(key)
+    if (!entry) {
+      return null
+    }
+
+    if (Date.now() >= entry.expiresAt) {
+      this.store.delete(key)
+      return null
+    }
+
+    this.store.delete(key)
+    this.store.set(key, entry)
+    return entry.value
+  }
+
+  /** キャッシュに翻訳結果を保存する。 */
+  set(key: string, value: string): void {
+    if (!this.config.enabled) {
+      return
+    }
+
+    if (
+      !Number.isFinite(this.config.ttlMs) ||
+      !Number.isFinite(this.config.maxItems)
+    ) {
+      return
+    }
+
+    if (this.config.ttlMs <= 0 || this.config.maxItems <= 0) {
+      return
+    }
+
+    const expiresAt = Date.now() + this.config.ttlMs
+    this.store.delete(key)
+    this.store.set(key, { value, expiresAt })
+    this.evictIfNeeded()
+  }
+
+  /** LRU に基づいて古いエントリーを削除する。 */
+  private evictIfNeeded(): void {
+    if (this.store.size <= this.config.maxItems) {
+      return
+    }
+
+    const overflow = this.store.size - this.config.maxItems
+    for (let i = 0; i < overflow; i += 1) {
+      const oldestKey = this.store.keys().next().value
+      if (!oldestKey) {
+        break
+      }
+      this.store.delete(oldestKey)
+    }
+  }
+}

--- a/src/translation-cache.ts
+++ b/src/translation-cache.ts
@@ -13,6 +13,20 @@ export class TranslationCache {
   /** 翻訳キャッシュを初期化する。 */
   constructor(private config: TranslationCacheConfig) {}
 
+  /** キャッシュが有効かどうかを判定する。 */
+  isEnabled(): boolean {
+    if (!this.config.enabled) {
+      return false
+    }
+    if (
+      !Number.isFinite(this.config.ttlMs) ||
+      !Number.isFinite(this.config.maxItems)
+    ) {
+      return false
+    }
+    return this.config.ttlMs > 0 && this.config.maxItems > 0
+  }
+
   /** キャッシュから翻訳結果を取得する。 */
   get(key: string): string | null {
     if (!this.config.enabled) {
@@ -72,7 +86,7 @@ export class TranslationCache {
     const overflow = this.store.size - this.config.maxItems
     for (let i = 0; i < overflow; i += 1) {
       const oldestKey = this.store.keys().next().value
-      if (!oldestKey) {
+      if (oldestKey === undefined) {
         break
       }
       this.store.delete(oldestKey)

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1,34 +1,76 @@
+import { createHash } from 'node:crypto'
 import axios from 'axios'
 import {
   GASTranslateRequest,
   GASBatchTranslateRequest,
   GASBatchTranslateResponse,
   BatchTranslateItem,
+  TranslationCacheConfig,
 } from './types.js'
+import { TranslationCache } from './translation-cache.js'
 
 export class Translator {
-  constructor(private gasUrl: string) {}
+  private gasUrl: string
+  private cache: TranslationCache
 
+  /** 翻訳クライアントを初期化する。 */
+  constructor(gasUrl: string, cacheConfig?: TranslationCacheConfig) {
+    this.gasUrl = gasUrl
+    this.cache = new TranslationCache(
+      cacheConfig ?? { enabled: false, ttlMs: 0, maxItems: 0 }
+    )
+  }
+
+  /** 翻訳キャッシュのキーを生成する。 */
+  private createCacheKey(
+    text: string,
+    sourceLang: string,
+    targetLang: string
+  ): string {
+    const hash = createHash('sha256').update(text).digest('hex')
+    return `${sourceLang}:${targetLang}:${hash}`
+  }
+
+  /** 複数テキストをまとめて翻訳する。 */
   async translateBatch(
     items: BatchTranslateItem[],
     sourceLang: string,
     targetLang: string
   ): Promise<Map<string, string>> {
     const results = new Map<string, string>()
+    const pendingItems: BatchTranslateItem[] = []
+    const cacheKeys = new Map<string, string>()
+
+    for (const item of items) {
+      const cacheKey = this.createCacheKey(item.text, sourceLang, targetLang)
+      const cached = this.cache.get(cacheKey)
+      if (cached !== null) {
+        results.set(item.id, cached)
+        continue
+      }
+      pendingItems.push(item)
+      cacheKeys.set(item.id, cacheKey)
+    }
+
+    if (pendingItems.length === 0) {
+      return results
+    }
 
     try {
       const request: GASBatchTranslateRequest = {
         batch: true,
         before: sourceLang,
         after: targetLang,
-        texts: items,
+        texts: pendingItems,
         mode: 'html',
       }
 
-      console.log(`Sending batch request with ${items.length} items to GAS`)
+      console.log(
+        `Sending batch request with ${pendingItems.length} items to GAS`
+      )
       console.log(
         'First 3 items:',
-        items
+        pendingItems
           .slice(0, 3)
           .map((item) => ({ id: item.id, textLength: item.text.length }))
       )
@@ -61,6 +103,10 @@ export class Translator {
         for (const result of response.data.results) {
           if (result.success && result.translated) {
             results.set(result.id, result.translated)
+            const cacheKey = cacheKeys.get(result.id)
+            if (cacheKey) {
+              this.cache.set(cacheKey, result.translated)
+            }
           } else {
             console.log(`Translation failed for ${result.id}:`, result.error)
             // フォールバック：元のテキストを使用
@@ -84,7 +130,7 @@ export class Translator {
         console.error('Error response status:', axiosError.response?.status)
       }
       // フォールバック：元のテキストを使用
-      for (const item of items) {
+      for (const item of pendingItems) {
         results.set(item.id, item.text)
       }
     }
@@ -92,11 +138,18 @@ export class Translator {
     return results
   }
 
+  /** 単一テキストを翻訳する。 */
   async translate(
     text: string,
     sourceLang: string,
     targetLang: string
   ): Promise<string | null> {
+    const cacheKey = this.createCacheKey(text, sourceLang, targetLang)
+    const cached = this.cache.get(cacheKey)
+    if (cached !== null) {
+      return cached
+    }
+
     try {
       const request: GASTranslateRequest = {
         before: sourceLang,
@@ -115,7 +168,11 @@ export class Translator {
       })
 
       if (response.status === 200 && response.data.response?.status) {
-        return response.data.response.result ?? null
+        const translated = response.data.response.result ?? null
+        if (translated !== null) {
+          this.cache.set(cacheKey, translated)
+        }
+        return translated
       }
 
       return null

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -40,16 +40,21 @@ export class Translator {
     const results = new Map<string, string>()
     const pendingItems: BatchTranslateItem[] = []
     const cacheKeys = new Map<string, string>()
+    const shouldUseCache = this.cache.isEnabled()
 
-    for (const item of items) {
-      const cacheKey = this.createCacheKey(item.text, sourceLang, targetLang)
-      const cached = this.cache.get(cacheKey)
-      if (cached !== null) {
-        results.set(item.id, cached)
-        continue
+    if (shouldUseCache) {
+      for (const item of items) {
+        const cacheKey = this.createCacheKey(item.text, sourceLang, targetLang)
+        const cached = this.cache.get(cacheKey)
+        if (cached !== null) {
+          results.set(item.id, cached)
+          continue
+        }
+        pendingItems.push(item)
+        cacheKeys.set(item.id, cacheKey)
       }
-      pendingItems.push(item)
-      cacheKeys.set(item.id, cacheKey)
+    } else {
+      pendingItems.push(...items)
     }
 
     if (pendingItems.length === 0) {
@@ -103,9 +108,11 @@ export class Translator {
         for (const result of response.data.results) {
           if (result.success && result.translated) {
             results.set(result.id, result.translated)
-            const cacheKey = cacheKeys.get(result.id)
-            if (cacheKey) {
-              this.cache.set(cacheKey, result.translated)
+            if (shouldUseCache) {
+              const cacheKey = cacheKeys.get(result.id)
+              if (cacheKey) {
+                this.cache.set(cacheKey, result.translated)
+              }
             }
           } else {
             console.log(`Translation failed for ${result.id}:`, result.error)
@@ -144,10 +151,16 @@ export class Translator {
     sourceLang: string,
     targetLang: string
   ): Promise<string | null> {
-    const cacheKey = this.createCacheKey(text, sourceLang, targetLang)
-    const cached = this.cache.get(cacheKey)
-    if (cached !== null) {
-      return cached
+    const shouldUseCache = this.cache.isEnabled()
+    const cacheKey = shouldUseCache
+      ? this.createCacheKey(text, sourceLang, targetLang)
+      : ''
+
+    if (shouldUseCache) {
+      const cached = this.cache.get(cacheKey)
+      if (cached !== null) {
+        return cached
+      }
     }
 
     try {
@@ -169,7 +182,7 @@ export class Translator {
 
       if (response.status === 200 && response.data.response?.status) {
         const translated = response.data.response.result ?? null
-        if (translated !== null) {
+        if (translated !== null && shouldUseCache) {
           this.cache.set(cacheKey, translated)
         }
         return translated

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+/** アプリケーション設定。 */
 export interface Config {
   gasUrl: string
   port?: number
@@ -6,8 +7,25 @@ export interface Config {
   defaultTargetLang?: string
   defaultExcludeFeedTitle?: boolean
   defaultExcludeItemTitle?: boolean
+  translationCache: TranslationCacheConfig
+  cacheControl: CacheControlConfig
 }
 
+/** 翻訳キャッシュ設定。 */
+export interface TranslationCacheConfig {
+  enabled: boolean
+  ttlMs: number
+  maxItems: number
+}
+
+/** CDN キャッシュ設定。 */
+export interface CacheControlConfig {
+  enabled: boolean
+  sMaxAge: number
+  staleWhileRevalidate: number
+}
+
+/** 翻訳 API のリクエストパラメータ。 */
 export interface TranslateRequest {
   url: string
   sourceLang?: string
@@ -16,12 +34,14 @@ export interface TranslateRequest {
   excludeItemTitle?: string
 }
 
+/** 翻訳 API のレスポンス。 */
 export interface TranslateResponse {
   status: 'success' | 'error'
   data?: string
   error?: string
 }
 
+/** GAS 翻訳リクエスト。 */
 export interface GASTranslateRequest {
   before: string
   after: string
@@ -29,15 +49,18 @@ export interface GASTranslateRequest {
   mode: 'html'
 }
 
+/** GAS 翻訳レスポンス。 */
 export interface GASTranslateResponse {
   text: string
 }
 
+/** バッチ翻訳の入力項目。 */
 export interface BatchTranslateItem {
   id: string
   text: string
 }
 
+/** GAS バッチ翻訳リクエスト。 */
 export interface GASBatchTranslateRequest {
   batch: true
   before: string
@@ -46,6 +69,7 @@ export interface GASBatchTranslateRequest {
   mode: 'html'
 }
 
+/** バッチ翻訳の結果。 */
 export interface BatchTranslateResult {
   id: string
   original: string
@@ -54,6 +78,7 @@ export interface BatchTranslateResult {
   error?: string
 }
 
+/** GAS バッチ翻訳レスポンス。 */
 export interface GASBatchTranslateResponse {
   status: boolean
   results: BatchTranslateResult[]
@@ -62,6 +87,7 @@ export interface GASBatchTranslateResponse {
   executionTime: number
 }
 
+/** RSS アイテム。 */
 export interface RSSItem {
   title?: string
   link?: string
@@ -75,6 +101,7 @@ export interface RSSItem {
   [key: string]: unknown
 }
 
+/** RSS フィード。 */
 export interface RSSFeed {
   title?: string
   link?: string
@@ -85,6 +112,7 @@ export interface RSSFeed {
   [key: string]: unknown
 }
 
+/** RSS XML 生成用のオブジェクト。 */
 export interface RSSObject {
   rss: {
     $: {


### PR DESCRIPTION
## 概要
- 翻訳結果のインメモリ LRU + TTL キャッシュを追加
- /api のレスポンスに Cache-Control (s-maxage と stale-while-revalidate) を付与
- 新規環境変数とドキュメント/テストを更新

## 変更内容
- 翻訳キャッシュ用の TranslationCache を追加し、Translator に組み込み
- RSSProcessor から翻訳キャッシュ設定を渡すように変更
- /api の Cache-Control ヘッダー生成を共通化し、テストも同じヘルパーを利用
- Cache-Control ヘッダーを設定し、CDN キャッシュを有効化
- キャッシュ無効時はハッシュ計算を省略するように isEnabled 判定を追加
- LRU 削除時の空文字キー判定を修正
- .env.example/README/AGENTS に設定項目を追記

## 影響と注意点
- キャッシュは同一インスタンス内のみ有効（Vercel Free ではベストエフォート）
- Cache-Control は config.cacheControl.enabled=false の場合は no-store を返す

## テスト
- pnpm lint
- pnpm test

## 判断記録
1. 判断内容の要約: 翻訳結果のキャッシュはインメモリ LRU + TTL を採用し、CDN キャッシュは Cache-Control で制御する
2. 検討した代替案: RSS 全体を URL 単位でキャッシュ、外部ストア（Redis/Vercel KV/Upstash）を使用
3. 採用しなかった案とその理由: RSS 全体キャッシュは更新遅延の影響が大きく、外部ストアは無料要件と運用負荷に合わないため
4. 前提条件・仮定・不確実性: Vercel のインスタンス再利用は保証されず、ヒット率はアクセス頻度に依存
5. 他エージェントによるレビュー可否: 可能

Closes #26
